### PR TITLE
chore(deps): bump up nitro to v0.28.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,11 @@
 
 A Simple React Native Nitro module for in-app browser.
 
-
 [![Build Android](https://github.com/patrickkabwe/react-native-nitro-in-app-browser/actions/workflows/android-build.yml/badge.svg)](https://github.com/patrickkabwe/react-native-nitro-in-app-browser/actions/workflows/android-build.yml)
 [![Build iOS](https://github.com/patrickkabwe/react-native-nitro-in-app-browser/actions/workflows/ios-build.yml/badge.svg)](https://github.com/patrickkabwe/react-native-nitro-in-app-browser/actions/workflows/ios-build.yml)
 
 [![npm version](https://img.shields.io/npm/v/react-native-nitro-in-app-browser.svg?style=flat-square)](https://www.npmjs.com/package/react-native-nitro-in-app-browser)
 [![npm downloads](https://img.shields.io/npm/dm/react-native-nitro-in-app-browser.svg?style=flat-square)](https://www.npmjs.com/package/react-native-nitro-in-app-browser)
-
-
 
 ## Installation
 
@@ -17,9 +14,8 @@ A Simple React Native Nitro module for in-app browser.
 > This package requires `react-native-nitro-modules` to be installed first.
 > See [react-native-nitro-modules](https://github.com/mrousavy/nitro) for more information.
 
-
 ```sh
-bun install react-native-nitro-in-app-browser react-native-nitro-modules@0.28.0
+bun install react-native-nitro-in-app-browser react-native-nitro-modules@0.28.1
 cd ios && pod install && cd ..
 ```
 
@@ -28,7 +24,7 @@ cd ios && pod install && cd ..
 ```js
 import React from 'react';
 import { Button, SafeAreaView } from 'react-native';
-import { NitroInAppBrowser } from 'react-native-nitro-in-app-browser';
+import NitroInAppBrowser from 'react-native-nitro-in-app-browser';
 
 const App = () => {
   return (
@@ -41,7 +37,7 @@ const App = () => {
               barColor: 'purple',
               controlColor: '#000000',
               dismissButtonLabel: 'close',
-              presentationStyle: "fullScreen",
+              presentationStyle: 'fullScreen',
             });
           } catch (error) {
             console.error(error);
@@ -56,13 +52,12 @@ export default App;
 ```
 
 ## License
-    
+
 MIT
 
 ---
 
 Bootstrapped with [Create Nitro Modules](https://github.com/patrickkabwe/create-nitro-module)
-
 
 ## Credits
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,11 +10,11 @@
         "@types/jest": "^29.5.12",
         "@types/react": "^19.0.10",
         "conventional-changelog-conventionalcommits": "^9.1.0",
-        "nitro-codegen": "^0.28.0",
+        "nitro-codegen": "^0.28.1",
         "react": "19.1.0",
         "react-native": "0.81.0",
         "react-native-builder-bob": "^0.37.0",
-        "react-native-nitro-modules": "^0.28.0",
+        "react-native-nitro-modules": "^0.28.1",
         "semantic-release": "^24.2.3",
         "typescript": "5.0.4",
       },
@@ -30,8 +30,8 @@
       "dependencies": {
         "react": "19.1.0",
         "react-native": "0.81.0",
-        "react-native-nitro-modules": "^0.28.0",
-        "react-native-safe-area-context": "^5.5.2",
+        "react-native-nitro-modules": "^0.28.1",
+        "react-native-safe-area-context": "^5.6.1",
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -690,7 +690,7 @@
 
     "chromium-edge-launcher": ["chromium-edge-launcher@0.2.0", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^1.0.0", "mkdirp": "^1.0.4", "rimraf": "^3.0.2" } }, "sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg=="],
 
-    "ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
+    "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
     "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
 
@@ -880,7 +880,7 @@
 
     "eslint-scope": ["eslint-scope@8.3.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ=="],
 
-    "eslint-visitor-keys": ["eslint-visitor-keys@4.2.0", "", {}, "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw=="],
+    "eslint-visitor-keys": ["eslint-visitor-keys@2.1.0", "", {}, "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="],
 
     "espree": ["espree@10.3.0", "", { "dependencies": { "acorn": "^8.14.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.0" } }, "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg=="],
 
@@ -1512,9 +1512,9 @@
 
     "react-native-nitro-in-app-browser-example": ["react-native-nitro-in-app-browser-example@workspace:example"],
 
-    "react-native-nitro-modules": ["react-native-nitro-modules@0.28.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-SR5fpEOxuzqObowLzwrAU7Pv9Kq+AcxKBTCprMcsaiNlURhex2R8T8moSU/hpZO8Vuf3iomdkzEVEIO8udSZ/w=="],
+    "react-native-nitro-modules": ["react-native-nitro-modules@0.28.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-+H9ORJ2WIF17ytQS3MmXJnZnGjp/cSFNFgVkX+6f+uGGrCebFzPyyoks3mPIQ0C4rYuI4sv4ltuR0jQCnPjlqw=="],
 
-    "react-native-safe-area-context": ["react-native-safe-area-context@5.6.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-tJas3YOdsuCg3kepCTGF3LWZp9onMbb9Agju2xfs2kRX8d/5TMUPmupBpjerk/B7Tv/zeJnk+qp5neA96Y0otQ=="],
+    "react-native-safe-area-context": ["react-native-safe-area-context@5.6.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA=="],
 
     "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
 
@@ -1838,8 +1838,6 @@
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@babel/eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@2.1.0", "", {}, "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="],
-
     "@babel/eslint-parser/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -1964,6 +1962,8 @@
 
     "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "eslint/eslint-visitor-keys": ["eslint-visitor-keys@4.2.0", "", {}, "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw=="],
+
     "eslint/zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "eslint-plugin-eslint-comments/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
@@ -1973,6 +1973,8 @@
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "espree/eslint-visitor-keys": ["eslint-visitor-keys@4.2.0", "", {}, "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw=="],
 
     "express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -2022,8 +2024,6 @@
 
     "jest-util/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "jest-util/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
-
     "jest-validate/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
@@ -2042,6 +2042,8 @@
 
     "metro/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
+
     "metro/metro-cache": ["metro-cache@0.83.1", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.1" } }, "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ=="],
 
     "metro/metro-config": ["metro-config@0.83.1", "", { "dependencies": { "connect": "^3.6.5", "cosmiconfig": "^5.0.5", "flow-enums-runtime": "^0.0.6", "jest-validate": "^29.7.0", "metro": "0.83.1", "metro-cache": "0.83.1", "metro-core": "0.83.1", "metro-runtime": "0.83.1" } }, "sha512-HJhpZx3wyOkux/jeF1o7akFJzZFdbn6Zf7UQqWrvp7gqFqNulQ8Mju09raBgPmmSxKDl4LbbNeigkX0/nKY1QA=="],
@@ -2059,8 +2061,6 @@
     "metro-config/metro-runtime": ["metro-runtime@0.80.12", "", { "dependencies": { "@babel/runtime": "^7.25.0", "flow-enums-runtime": "^0.0.6" } }, "sha512-LIx7+92p5rpI0i6iB4S4GBvvLxStNt6fF0oPMaUd1Weku7jZdfkCZzmrtDD9CSQ6EPb0T9NUZoyXIxlBa3wOCw=="],
 
     "metro-transform-worker/metro-cache": ["metro-cache@0.83.1", "", { "dependencies": { "exponential-backoff": "^3.1.1", "flow-enums-runtime": "^0.0.6", "https-proxy-agent": "^7.0.5", "metro-core": "0.83.1" } }, "sha512-7N/Ad1PHa1YMWDNiyynTPq34Op2qIE68NWryGEQ4TSE3Zy6a8GpsYnEEZE4Qi6aHgsE+yZHKkRczeBgxhnFIxQ=="],
-
-    "nitro-codegen/react-native-nitro-modules": ["react-native-nitro-modules@0.28.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-+H9ORJ2WIF17ytQS3MmXJnZnGjp/cSFNFgVkX+6f+uGGrCebFzPyyoks3mPIQ0C4rYuI4sv4ltuR0jQCnPjlqw=="],
 
     "normalize-package-data/hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
 
@@ -2671,6 +2671,8 @@
     "metro-config/cosmiconfig/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "^1.3.1", "json-parse-better-errors": "^1.0.1" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
 
     "metro-config/metro/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "metro-config/metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
     "metro-config/metro/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.0):
     - hermes-engine/Pre-built (= 0.81.0)
   - hermes-engine/Pre-built (0.81.0)
-  - NitroInAppBrowser (1.2.0):
+  - NitroInAppBrowser (2.0.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -38,7 +38,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - NitroModules (0.28.0):
+  - NitroModules (0.28.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -1778,7 +1778,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - react-native-safe-area-context (5.6.0):
+  - react-native-safe-area-context (5.6.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -1796,8 +1796,8 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-safe-area-context/common (= 5.6.0)
-    - react-native-safe-area-context/fabric (= 5.6.0)
+    - react-native-safe-area-context/common (= 5.6.1)
+    - react-native-safe-area-context/fabric (= 5.6.1)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -1808,7 +1808,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-safe-area-context/common (5.6.0):
+  - react-native-safe-area-context/common (5.6.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -1836,7 +1836,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-safe-area-context/fabric (5.6.0):
+  - react-native-safe-area-context/fabric (5.6.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -2613,8 +2613,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: e7491a2038f2618c8cd444ed411a6deb350a3742
-  NitroInAppBrowser: 001bd2e0c2d85effb24db4c53e4e966f6f392df3
-  NitroModules: 54b9c7efd517b142c015a4a8dff49c779191627c
+  NitroInAppBrowser: 4764292dc9ceebfbc7ea1e60d6a0dda248708b33
+  NitroModules: 58f33f6f7137aa5461298a0495b3e7a3a6fdea9d
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 0735ab4f6b3ec93a7f98187b5da74d7916e2cf4c
   RCTRequired: 8fcc7801bfc433072287b0f24a662e2816e89d0c
@@ -2648,7 +2648,7 @@ SPEC CHECKSUMS:
   React-logger: 04ce9229cb57db2c2a8164eaec1105f89da7fb22
   React-Mapbuffer: e402e7a0535b2213c50727553621480fe8cd8ade
   React-microtasksnativemodule: a63ce5595016996a9bac1f10c70a7a7fe6506649
-  react-native-safe-area-context: a72764e0eb5d6b79b7450e5d0ae919eb1a4567b4
+  react-native-safe-area-context: c6e2edd1c1da07bdce287fa9d9e60c5f7b514616
   React-NativeModulesApple: b3766e1f87b08064ebc459b9e1538da2447ca874
   React-oscompat: 34f3d3c06cadcbc470bc4509c717fb9b919eaa8b
   React-perflogger: a1edb025fd5d44f61bf09307e248f7608d7b2dcf

--- a/nitrogen/generated/ios/NitroInAppBrowser-Swift-Cxx-Bridge.cpp
+++ b/nitrogen/generated/ios/NitroInAppBrowser-Swift-Cxx-Bridge.cpp
@@ -14,7 +14,7 @@
 namespace margelo::nitro::nitroinappbrowser::bridge::swift {
 
   // pragma MARK: std::function<void()>
-  Func_void create_Func_void(void* _Nonnull swiftClosureWrapper) {
+  Func_void create_Func_void(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroInAppBrowser::Func_void::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)]() mutable -> void {
       swiftClosure.call();
@@ -22,7 +22,7 @@ namespace margelo::nitro::nitroinappbrowser::bridge::swift {
   }
   
   // pragma MARK: std::function<void(const std::exception_ptr& /* error */)>
-  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull swiftClosureWrapper) {
+  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull swiftClosureWrapper) noexcept {
     auto swiftClosure = NitroInAppBrowser::Func_void_std__exception_ptr::fromUnsafe(swiftClosureWrapper);
     return [swiftClosure = std::move(swiftClosure)](const std::exception_ptr& error) mutable -> void {
       swiftClosure.call(error);
@@ -30,11 +30,11 @@ namespace margelo::nitro::nitroinappbrowser::bridge::swift {
   }
   
   // pragma MARK: std::shared_ptr<HybridNitroInAppBrowserSpec>
-  std::shared_ptr<HybridNitroInAppBrowserSpec> create_std__shared_ptr_HybridNitroInAppBrowserSpec_(void* _Nonnull swiftUnsafePointer) {
+  std::shared_ptr<HybridNitroInAppBrowserSpec> create_std__shared_ptr_HybridNitroInAppBrowserSpec_(void* _Nonnull swiftUnsafePointer) noexcept {
     NitroInAppBrowser::HybridNitroInAppBrowserSpec_cxx swiftPart = NitroInAppBrowser::HybridNitroInAppBrowserSpec_cxx::fromUnsafe(swiftUnsafePointer);
     return std::make_shared<margelo::nitro::nitroinappbrowser::HybridNitroInAppBrowserSpecSwift>(swiftPart);
   }
-  void* _Nonnull get_std__shared_ptr_HybridNitroInAppBrowserSpec_(std__shared_ptr_HybridNitroInAppBrowserSpec_ cppType) {
+  void* _Nonnull get_std__shared_ptr_HybridNitroInAppBrowserSpec_(std__shared_ptr_HybridNitroInAppBrowserSpec_ cppType) noexcept {
     std::shared_ptr<margelo::nitro::nitroinappbrowser::HybridNitroInAppBrowserSpecSwift> swiftWrapper = std::dynamic_pointer_cast<margelo::nitro::nitroinappbrowser::HybridNitroInAppBrowserSpecSwift>(cppType);
     #ifdef NITRO_DEBUG
     if (swiftWrapper == nullptr) [[unlikely]] {

--- a/nitrogen/generated/ios/NitroInAppBrowser-Swift-Cxx-Bridge.hpp
+++ b/nitrogen/generated/ios/NitroInAppBrowser-Swift-Cxx-Bridge.hpp
@@ -46,10 +46,10 @@ namespace margelo::nitro::nitroinappbrowser::bridge::swift {
    * Specialized version of `std::shared_ptr<Promise<void>>`.
    */
   using std__shared_ptr_Promise_void__ = std::shared_ptr<Promise<void>>;
-  inline std::shared_ptr<Promise<void>> create_std__shared_ptr_Promise_void__() {
+  inline std::shared_ptr<Promise<void>> create_std__shared_ptr_Promise_void__() noexcept {
     return Promise<void>::create();
   }
-  inline PromiseHolder<void> wrap_std__shared_ptr_Promise_void__(std::shared_ptr<Promise<void>> promise) {
+  inline PromiseHolder<void> wrap_std__shared_ptr_Promise_void__(std::shared_ptr<Promise<void>> promise) noexcept {
     return PromiseHolder<void>(std::move(promise));
   }
   
@@ -64,14 +64,14 @@ namespace margelo::nitro::nitroinappbrowser::bridge::swift {
   class Func_void_Wrapper final {
   public:
     explicit Func_void_Wrapper(std::function<void()>&& func): _function(std::make_unique<std::function<void()>>(std::move(func))) {}
-    inline void call() const {
+    inline void call() const noexcept {
       _function->operator()();
     }
   private:
     std::unique_ptr<std::function<void()>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void create_Func_void(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_Wrapper wrap_Func_void(Func_void value) {
+  Func_void create_Func_void(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_Wrapper wrap_Func_void(Func_void value) noexcept {
     return Func_void_Wrapper(std::move(value));
   }
   
@@ -86,14 +86,14 @@ namespace margelo::nitro::nitroinappbrowser::bridge::swift {
   class Func_void_std__exception_ptr_Wrapper final {
   public:
     explicit Func_void_std__exception_ptr_Wrapper(std::function<void(const std::exception_ptr& /* error */)>&& func): _function(std::make_unique<std::function<void(const std::exception_ptr& /* error */)>>(std::move(func))) {}
-    inline void call(std::exception_ptr error) const {
+    inline void call(std::exception_ptr error) const noexcept {
       _function->operator()(error);
     }
   private:
     std::unique_ptr<std::function<void(const std::exception_ptr& /* error */)>> _function;
   } SWIFT_NONCOPYABLE;
-  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull swiftClosureWrapper);
-  inline Func_void_std__exception_ptr_Wrapper wrap_Func_void_std__exception_ptr(Func_void_std__exception_ptr value) {
+  Func_void_std__exception_ptr create_Func_void_std__exception_ptr(void* _Nonnull swiftClosureWrapper) noexcept;
+  inline Func_void_std__exception_ptr_Wrapper wrap_Func_void_std__exception_ptr(Func_void_std__exception_ptr value) noexcept {
     return Func_void_std__exception_ptr_Wrapper(std::move(value));
   }
   
@@ -102,8 +102,14 @@ namespace margelo::nitro::nitroinappbrowser::bridge::swift {
    * Specialized version of `std::optional<NitroInAppBrowserDismissButtonLabel>`.
    */
   using std__optional_NitroInAppBrowserDismissButtonLabel_ = std::optional<NitroInAppBrowserDismissButtonLabel>;
-  inline std::optional<NitroInAppBrowserDismissButtonLabel> create_std__optional_NitroInAppBrowserDismissButtonLabel_(const NitroInAppBrowserDismissButtonLabel& value) {
+  inline std::optional<NitroInAppBrowserDismissButtonLabel> create_std__optional_NitroInAppBrowserDismissButtonLabel_(const NitroInAppBrowserDismissButtonLabel& value) noexcept {
     return std::optional<NitroInAppBrowserDismissButtonLabel>(value);
+  }
+  inline bool has_value_std__optional_NitroInAppBrowserDismissButtonLabel_(const std::optional<NitroInAppBrowserDismissButtonLabel>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline NitroInAppBrowserDismissButtonLabel get_std__optional_NitroInAppBrowserDismissButtonLabel_(const std::optional<NitroInAppBrowserDismissButtonLabel>& optional) noexcept {
+    return *optional;
   }
   
   // pragma MARK: std::optional<NitroInAppBrowserPresentationStyle>
@@ -111,8 +117,14 @@ namespace margelo::nitro::nitroinappbrowser::bridge::swift {
    * Specialized version of `std::optional<NitroInAppBrowserPresentationStyle>`.
    */
   using std__optional_NitroInAppBrowserPresentationStyle_ = std::optional<NitroInAppBrowserPresentationStyle>;
-  inline std::optional<NitroInAppBrowserPresentationStyle> create_std__optional_NitroInAppBrowserPresentationStyle_(const NitroInAppBrowserPresentationStyle& value) {
+  inline std::optional<NitroInAppBrowserPresentationStyle> create_std__optional_NitroInAppBrowserPresentationStyle_(const NitroInAppBrowserPresentationStyle& value) noexcept {
     return std::optional<NitroInAppBrowserPresentationStyle>(value);
+  }
+  inline bool has_value_std__optional_NitroInAppBrowserPresentationStyle_(const std::optional<NitroInAppBrowserPresentationStyle>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline NitroInAppBrowserPresentationStyle get_std__optional_NitroInAppBrowserPresentationStyle_(const std::optional<NitroInAppBrowserPresentationStyle>& optional) noexcept {
+    return *optional;
   }
   
   // pragma MARK: std::optional<std::string>
@@ -120,8 +132,14 @@ namespace margelo::nitro::nitroinappbrowser::bridge::swift {
    * Specialized version of `std::optional<std::string>`.
    */
   using std__optional_std__string_ = std::optional<std::string>;
-  inline std::optional<std::string> create_std__optional_std__string_(const std::string& value) {
+  inline std::optional<std::string> create_std__optional_std__string_(const std::string& value) noexcept {
     return std::optional<std::string>(value);
+  }
+  inline bool has_value_std__optional_std__string_(const std::optional<std::string>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline std::string get_std__optional_std__string_(const std::optional<std::string>& optional) noexcept {
+    return *optional;
   }
   
   // pragma MARK: std::optional<NitroInAppBrowserOptions>
@@ -129,8 +147,14 @@ namespace margelo::nitro::nitroinappbrowser::bridge::swift {
    * Specialized version of `std::optional<NitroInAppBrowserOptions>`.
    */
   using std__optional_NitroInAppBrowserOptions_ = std::optional<NitroInAppBrowserOptions>;
-  inline std::optional<NitroInAppBrowserOptions> create_std__optional_NitroInAppBrowserOptions_(const NitroInAppBrowserOptions& value) {
+  inline std::optional<NitroInAppBrowserOptions> create_std__optional_NitroInAppBrowserOptions_(const NitroInAppBrowserOptions& value) noexcept {
     return std::optional<NitroInAppBrowserOptions>(value);
+  }
+  inline bool has_value_std__optional_NitroInAppBrowserOptions_(const std::optional<NitroInAppBrowserOptions>& optional) noexcept {
+    return optional.has_value();
+  }
+  inline NitroInAppBrowserOptions get_std__optional_NitroInAppBrowserOptions_(const std::optional<NitroInAppBrowserOptions>& optional) noexcept {
+    return *optional;
   }
   
   // pragma MARK: std::shared_ptr<HybridNitroInAppBrowserSpec>
@@ -138,19 +162,19 @@ namespace margelo::nitro::nitroinappbrowser::bridge::swift {
    * Specialized version of `std::shared_ptr<HybridNitroInAppBrowserSpec>`.
    */
   using std__shared_ptr_HybridNitroInAppBrowserSpec_ = std::shared_ptr<HybridNitroInAppBrowserSpec>;
-  std::shared_ptr<HybridNitroInAppBrowserSpec> create_std__shared_ptr_HybridNitroInAppBrowserSpec_(void* _Nonnull swiftUnsafePointer);
-  void* _Nonnull get_std__shared_ptr_HybridNitroInAppBrowserSpec_(std__shared_ptr_HybridNitroInAppBrowserSpec_ cppType);
+  std::shared_ptr<HybridNitroInAppBrowserSpec> create_std__shared_ptr_HybridNitroInAppBrowserSpec_(void* _Nonnull swiftUnsafePointer) noexcept;
+  void* _Nonnull get_std__shared_ptr_HybridNitroInAppBrowserSpec_(std__shared_ptr_HybridNitroInAppBrowserSpec_ cppType) noexcept;
   
   // pragma MARK: std::weak_ptr<HybridNitroInAppBrowserSpec>
   using std__weak_ptr_HybridNitroInAppBrowserSpec_ = std::weak_ptr<HybridNitroInAppBrowserSpec>;
-  inline std__weak_ptr_HybridNitroInAppBrowserSpec_ weakify_std__shared_ptr_HybridNitroInAppBrowserSpec_(const std::shared_ptr<HybridNitroInAppBrowserSpec>& strong) { return strong; }
+  inline std__weak_ptr_HybridNitroInAppBrowserSpec_ weakify_std__shared_ptr_HybridNitroInAppBrowserSpec_(const std::shared_ptr<HybridNitroInAppBrowserSpec>& strong) noexcept { return strong; }
   
   // pragma MARK: Result<std::shared_ptr<Promise<void>>>
   using Result_std__shared_ptr_Promise_void___ = Result<std::shared_ptr<Promise<void>>>;
-  inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::shared_ptr<Promise<void>>& value) {
+  inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::shared_ptr<Promise<void>>& value) noexcept {
     return Result<std::shared_ptr<Promise<void>>>::withValue(value);
   }
-  inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::exception_ptr& error) {
+  inline Result_std__shared_ptr_Promise_void___ create_Result_std__shared_ptr_Promise_void___(const std::exception_ptr& error) noexcept {
     return Result<std::shared_ptr<Promise<void>>>::withError(error);
   }
 

--- a/nitrogen/generated/ios/swift/HybridNitroInAppBrowserSpec_cxx.swift
+++ b/nitrogen/generated/ios/swift/HybridNitroInAppBrowserSpec_cxx.swift
@@ -113,7 +113,8 @@ open class HybridNitroInAppBrowserSpec_cxx {
   public final func open(url: std.string, options: bridge.std__optional_NitroInAppBrowserOptions_) -> bridge.Result_std__shared_ptr_Promise_void___ {
     do {
       let __result = try self.__implementation.open(url: String(url), options: { () -> NitroInAppBrowserOptions? in
-        if let __unwrapped = options.value {
+        if bridge.has_value_std__optional_NitroInAppBrowserOptions_(options) {
+          let __unwrapped = bridge.get_std__optional_NitroInAppBrowserOptions_(options)
           return __unwrapped
         } else {
           return nil

--- a/nitrogen/generated/ios/swift/NitroInAppBrowserOptions.swift
+++ b/nitrogen/generated/ios/swift/NitroInAppBrowserOptions.swift
@@ -84,7 +84,8 @@ public extension NitroInAppBrowserOptions {
     @inline(__always)
     get {
       return { () -> String? in
-        if let __unwrapped = self.__barColor.value {
+        if bridge.has_value_std__optional_std__string_(self.__barColor) {
+          let __unwrapped = bridge.get_std__optional_std__string_(self.__barColor)
           return String(__unwrapped)
         } else {
           return nil
@@ -107,7 +108,8 @@ public extension NitroInAppBrowserOptions {
     @inline(__always)
     get {
       return { () -> String? in
-        if let __unwrapped = self.__controlColor.value {
+        if bridge.has_value_std__optional_std__string_(self.__controlColor) {
+          let __unwrapped = bridge.get_std__optional_std__string_(self.__controlColor)
           return String(__unwrapped)
         } else {
           return nil

--- a/package.json
+++ b/package.json
@@ -60,11 +60,11 @@
         "@types/jest": "^29.5.12",
         "@types/react": "^19.0.10",
         "conventional-changelog-conventionalcommits": "^9.1.0",
-        "nitro-codegen": "^0.28.0",
+        "nitro-codegen": "^0.28.1",
         "react": "19.1.0",
         "react-native": "0.81.0",
         "react-native-builder-bob": "^0.37.0",
-        "react-native-nitro-modules": "^0.28.0",
+        "react-native-nitro-modules": "^0.28.1",
         "semantic-release": "^24.2.3",
         "typescript": "5.0.4"
     },


### PR DESCRIPTION
- Bump nitro-codegen and react-native-nitro-modules to version 0.28.1.
- Update react-native-safe-area-context to version 5.6.1.
- Update README.md to reflect the new version of react-native-nitro-modules.
- Modify Swift-Cxx bridge methods to include noexcept for better error handling.
- Update Podfile.lock to reflect changes in NitroInAppBrowser and NitroModules versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to reflect default import usage for NitroInAppBrowser.
  * Refreshed installation instructions to reference react-native-nitro-modules@0.28.1.
  * Polished code samples (quote style) and cleaned up formatting, including license section.

* **Chores**
  * Bumped dev dependencies nitro-codegen and react-native-nitro-modules to ^0.28.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->